### PR TITLE
(HWAYNN-1106)|Fix encoding of URL query parameters

### DIFF
--- a/JSONRequest.xcodeproj/project.pbxproj
+++ b/JSONRequest.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		95975B081C1E2CFF004750A8 /* JSONRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95975B071C1E2CFF004750A8 /* JSONRequest.swift */; };
 		95975B0B1C1E31E0004750A8 /* JSONRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 95975B031C1E2CA0004750A8 /* JSONRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D4F9B0F01F268BE3004C6B15 /* testFiles in Resources */ = {isa = PBXBuildFile; fileRef = D4F9B0EF1F268BE3004C6B15 /* testFiles */; };
+		DA9BEACF1F2BF63700EEDC94 /* URLEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9BEACE1F2BF63700EEDC94 /* URLEncoding.swift */; };
 		F5CA216D29A78D7BD6E012C3 /* Pods_JSONRequestTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F6AFE01224BBF6E8DD4CBAD /* Pods_JSONRequestTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -58,6 +59,7 @@
 		95975B0E1C1F39D2004750A8 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		A262DBB8FA4EFE8496CA36C8 /* Pods-JSONRequest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JSONRequest.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JSONRequest/Pods-JSONRequest.debug.xcconfig"; sourceTree = "<group>"; };
 		D4F9B0EF1F268BE3004C6B15 /* testFiles */ = {isa = PBXFileReference; lastKnownFileType = folder; path = testFiles; sourceTree = "<group>"; };
+		DA9BEACE1F2BF63700EEDC94 /* URLEncoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = URLEncoding.swift; path = Sources/URLEncoding.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,6 +165,7 @@
 			children = (
 				95975B071C1E2CFF004750A8 /* JSONRequest.swift */,
 				9575F2081C448965000B5A59 /* JSONRequestVerbs.swift */,
+				DA9BEACE1F2BF63700EEDC94 /* URLEncoding.swift */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -379,6 +382,7 @@
 			files = (
 				9575F2091C448965000B5A59 /* JSONRequestVerbs.swift in Sources */,
 				95975B081C1E2CFF004750A8 /* JSONRequest.swift in Sources */,
+				DA9BEACF1F2BF63700EEDC94 /* URLEncoding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/JSONRequestTests/JSONRequestTests.swift
+++ b/JSONRequestTests/JSONRequestTests.swift
@@ -24,19 +24,26 @@ class JSONRequestTests: XCTestCase {
         XCTAssertNil(url)
     }
 
-    func testCreateEmptyURL() {
-        let jsonRequest = JSONRequest()
-        let url = jsonRequest.createURL(urlString: "", queryParams: nil)
-        XCTAssertNotNil(url)
-        XCTAssertEqual(url?.absoluteString, "")
-    }
-
     func testCreateURL() {
         let jsonRequest = JSONRequest()
         let url = jsonRequest.createURL(urlString: "http://httpbin.org",
                                         queryParams: nil)
         XCTAssertNotNil(url)
         XCTAssertEqual(url?.absoluteString, "http://httpbin.org")
+    }
+
+    func testEncodesBasicURLQueryParameters() {
+        let jsonRequest = JSONRequest()
+        let url = jsonRequest.createURL(urlString: "http://httpbin.org", queryParams: ["hello": "world"])
+        XCTAssertNotNil(url)
+        XCTAssert(url?.query == "hello=world")
+    }
+
+    func testEncodesEscapableURLQueryParameters() {
+        let jsonRequest = JSONRequest()
+        let url = jsonRequest.createURL(urlString: "http://httpbin.org", queryParams: ["hello!$&'()*+,;=:#[]@": "world!$&'()*+,;=:#[]@"])
+        XCTAssertNotNil(url)
+        XCTAssertEqual(url?.query, "hello%21%24%26%27%28%29%2A%2B%2C%3B%3D%3A%23%5B%5D%40=world%21%24%26%27%28%29%2A%2B%2C%3B%3D%3A%23%5B%5D%40")
     }
 
     func testCreateURLWithParam() {
@@ -60,21 +67,6 @@ class JSONRequestTests: XCTestCase {
         XCTAssert(url?.absoluteString.contains("aaaa=1") ?? false)
         XCTAssert(url?.absoluteString.contains("bbbb=string") ?? false)
         XCTAssert(url?.absoluteString.contains("cccc=2.2") ?? false)
-    }
-
-    func testCreateURLWithNilParams() {
-        let jsonRequest = JSONRequest()
-        let params: JSONObject = [
-            "aaaa": 1,
-            "bbbb": "string",
-            "cccc": 5.5
-        ]
-        let url = jsonRequest.createURL(urlString: "http://httpbin.org", queryParams: params)
-        XCTAssertNotNil(url)
-        XCTAssertNotNil(url?.absoluteString)
-        XCTAssertEqual(url?.absoluteString.contains("aaaa=1"), true)
-        XCTAssertEqual(url?.absoluteString.contains("bbbb=string"), true)
-        XCTAssertEqual(url?.absoluteString.contains("cccc=5.5"), true)
     }
 
     func testCreateURLWithUrlParams() {

--- a/Sources/JSONRequest.swift
+++ b/Sources/JSONRequest.swift
@@ -186,17 +186,14 @@ open class JSONRequest {
     }
 
     open func createURL(urlString: String, queryParams: JSONObject?) -> URL? {
-        var components = URLComponents(string: urlString)
-        if queryParams != nil {
-            if components?.queryItems == nil {
-                components?.queryItems = []
-            }
-            for (key, value) in queryParams! {
-                let item = URLQueryItem(name: key, value: String(describing: value))
-                components?.queryItems?.append(item)
-            }
+        guard let baseURL = URL(string: urlString) else {
+            return nil
         }
-        return components?.url
+        guard let queryParams = queryParams else {
+            return baseURL
+        }
+
+        return url(baseURL, appendingPercentEncodingOf: queryParams)
     }
 
     func parse(data: Data?, response: URLResponse?) -> JSONResult {

--- a/Sources/URLEncoding.swift
+++ b/Sources/URLEncoding.swift
@@ -1,0 +1,134 @@
+//
+//  URLEncoding.swift
+//  JSONRequest
+//
+//  Created by Matt Holden on 7/28/17.
+//  Copyright © 2017 Hathway. All rights reserved.
+//
+
+import Foundation
+
+// This code is ported from Alamofire's `URLEncoding` struct:
+// https://github.com/Alamofire/Alamofire/blob/5bd458ca09a57fb2999772745d6438585f5140a7/Source/ParameterEncoding.swift
+// (Alamofire is MIT-licensed)
+
+/// Appends a dictionary of query parameters to a URL, properly percent-encoding the parameters, according to RFC 3986.
+/// - parameter url: The URL to append `parameters` to. Any existing percent-encoding in the original URL will be preserved.
+/// - parameter parameters: A dictionary of parameters to encode and append to the `query` of `url`
+/// - note: Since there is no published specification for how to encode
+///   collection types, this function follows the convention of appending `[]` to the key for array values (`foo[]=1&foo[]=2`),
+///   and appending the key surrounded by square brackets for nested dictionary values (`foo[bar]=baz`).
+internal func url(_ url: URL, appendingPercentEncodingOf parameters: [String: Any]) -> URL {
+    guard var comp = URLComponents(url: url, resolvingAgainstBaseURL: false), !parameters.isEmpty else {
+        return url
+    }
+
+    let existingQuery = comp.percentEncodedQuery.map { $0 + "&" } ?? ""
+    comp.percentEncodedQuery = "\(existingQuery)\(query(parameters))"
+
+    return comp.url!
+}
+
+/// Creates percent-escaped, URL encoded query string components from the given key-value pair using recursion.
+///
+/// - parameter key:   The key of the query component.
+/// - parameter value: The value of the query component.
+///
+/// - returns: The percent-escaped, URL encoded query string components.
+private func queryComponents(fromKey key: String, value: Any) -> [(String, String)] {
+    var components: [(String, String)] = []
+
+    if let dictionary = value as? [String: Any] {
+        for (nestedKey, value) in dictionary {
+            components += queryComponents(fromKey: "\(key)[\(nestedKey)]", value: value)
+        }
+    } else if let array = value as? [Any] {
+        for value in array {
+            components += queryComponents(fromKey: "\(key)[]", value: value)
+        }
+    } else if let value = value as? NSNumber {
+        if isBoolean(number: value) {
+            components.append((escape(key), escape((value.boolValue ? "1" : "0"))))
+        } else {
+            components.append((escape(key), escape("\(value)")))
+        }
+    } else if let bool = value as? Bool {
+        components.append((escape(key), escape((bool ? "1" : "0"))))
+    } else {
+        components.append((escape(key), escape("\(value)")))
+    }
+
+    return components
+}
+
+/// Returns a percent-escaped string following RFC 3986 for a query string key or value.
+///
+/// RFC 3986 states that the following characters are "reserved" characters.
+///
+/// - General Delimiters: ":", "#", "[", "]", "@", "?", "/"
+/// - Sub-Delimiters: "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "="
+///
+/// In RFC 3986 - Section 3.4, it states that the "?" and "/" characters should not be escaped to allow
+/// query strings to include a URL. Therefore, all "reserved" characters with the exception of "?" and "/"
+/// should be percent-escaped in the query string.
+///
+/// - parameter string: The string to be percent-escaped.
+///
+/// - returns: The percent-escaped string.
+private func escape(_ string: String) -> String {
+    let generalDelimitersToEncode = ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
+    let subDelimitersToEncode = "!$&'()*+,;="
+
+    var allowedCharacterSet = CharacterSet.urlQueryAllowed
+    allowedCharacterSet.remove(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
+
+    var escaped = ""
+
+    //==========================================================================================================
+    //
+    //  Batching is required for escaping due to an internal bug in iOS 8.1 and 8.2. Encoding more than a few
+    //  hundred Chinese characters causes various malloc error crashes. To avoid this issue until iOS 8 is no
+    //  longer supported, batching MUST be used for encoding. This introduces roughly a 20% overhead. For more
+    //  info, please refer to:
+    //
+    //      - https://github.com/Alamofire/Alamofire/issues/206
+    //
+    //==========================================================================================================
+
+    if #available(iOS 8.3, *) {
+        escaped = string.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) ?? string
+    } else {
+        let batchSize = 50
+        var index = string.startIndex
+
+        while index != string.endIndex {
+            let startIndex = index
+            let endIndex = string.index(index, offsetBy: batchSize, limitedBy: string.endIndex) ?? string.endIndex
+            let range = startIndex..<endIndex
+
+            let substring = string.substring(with: range)
+
+            escaped += substring.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) ?? substring
+
+            index = endIndex
+        }
+    }
+
+    return escaped
+}
+
+private func query(_ parameters: [String: Any]) -> String {
+    var components: [(String, String)] = []
+
+    for key in parameters.keys.sorted(by: <) {
+        let value = parameters[key]!
+        components += queryComponents(fromKey: key, value: value)
+    }
+    return components.map { "\($0)=\($1)" }.joined(separator: "&")
+}
+
+
+/// Checks that the underling type of a given NSNumber is a Bool
+private func isBoolean(number: NSNumber) -> Bool {
+    return CFBooleanGetTypeID() == CFGetTypeID(number)
+}


### PR DESCRIPTION
##Summary

Apple's implementation of query parameters in URLComponents does not
encode all characters that need to be escaped according to RFC 3986
(https://www.ietf.org/rfc/rfc3986.txt, page 12)

The popular Alamofire networking library handles this problem by manually
encoding query parameters. Because this library is battle-tested, I
copied its URL encoding code, modifying it only slightly. (It's `encode`
function accepts a URLRequest as input and returns a modified
URLRequest. Our implementation accepts and returns an updated `URL`.)

An additional win is that Alamofire's implementation properly encodes
arrays and dictionaries into URL query strings.

##Tests

**Adds two tests:**
- Encoding basic URL parameters (aka "hello=world")
- Encoding URL parameters that need escaping (&'()*+,;=:#[]@)

**Removes one test:**

There was a test asserting that creating a `URL` from an empty string
would return a non-nil `URL`, with an absolute string value of `""`.
This is NOT the behavior when using the `URL(string:)` initializer, but IS
the behavior when initializing through `URLComponents`, which yields:
`URLComponents(string "")!.url == ""`.

This behavior is certainly unexpected, and it's really strange the
original author (Eneko) chose to test for this behavior, especially when
the tested method returns an optional `URL`: `func createURL(urlString:, queryParams:) -> URL?`.

This might be a (odd) breaking change for client code, but because the
intention is to tag this version 1.0, not compatible with previous
versions, this feels appropriate.