### PR TITLE
[WIP] Better support for HTTP caching

### DIFF
--- a/Sources/JSONRequest.swift
+++ b/Sources/JSONRequest.swift
@@ -149,11 +149,13 @@ open class JSONRequest {
         updateRequest(&request, headers: headers)
         updateRequest(&request, payload: payload)
 
-        let session = urlSession ?? networkSession()
+        let session = (timeOut == urlSession?.configuration.timeoutIntervalForRequest
+            ? (urlSession ?? networkSession())
+            : networkSession(forcedTimeout: timeOut))
         let start = Date()
 
         let cachedResponse: CachedURLResponse? = session.configuration.urlCache?.cachedResponse(for: request)
-        if let cache = session.configuration.urlCache, cachedResponse == nil {
+        if cachedResponse == nil {
             removeCachingHeaders(&request)
         }
 
@@ -193,9 +195,16 @@ open class JSONRequest {
     }
 
     func networkSession(forcedTimeout: TimeInterval? = nil) -> URLSession {
-        guard urlSession == nil else { return urlSession! }
-        urlSession = URLSession(configuration: JSONRequest.sessionConfig)
-        return urlSession!
+        let config = JSONRequest.sessionConfig
+        if let timeout = forcedTimeout {
+            config.timeoutIntervalForRequest = timeout
+        }
+        let session = URLSession(configuration: config)
+        if forcedTimeout == nil {
+            // if there isn't a custom timeout, set the member variable with this new session we've created for future use.
+            urlSession = session
+        }
+        return session
     }
 
     func submitSyncRequest(method: JSONRequestHttpVerb, url: String,

--- a/Sources/JSONRequest.swift
+++ b/Sources/JSONRequest.swift
@@ -198,6 +198,7 @@ open class JSONRequest {
         let config = JSONRequest.sessionConfig
         if let timeout = forcedTimeout {
             config.timeoutIntervalForRequest = timeout
+            config.timeoutIntervalForResource = timeout
         }
         let session = URLSession(configuration: config)
         if forcedTimeout == nil {


### PR DESCRIPTION
The way JSONRequest was built was to dynamically create new URLSessionConfiguration and URLSession objects for each and every request. I have observed that this can cause some strange caching behavior where sometimes the HTTP request that is returned by the server is a 304 Not Modified, but the data returned to the application layer is also a 304, instead of a 200 OK with the cached data (which represents transparent caching to the application layer).

I have made the URLSession object persistent for all requests, and it gets updated only when a JSONRequest property changes that requires a corresponding change to the URLSessionConfiguration object.

I don't anticipate that this will have any effect beyond caching implications, but since we don't have automated unit tests I'm not 100% sure what the impact might be. For now I will point my client project to this particular branch so we don't have to rush to get this into master if there is debate/discussion as to the PR's merit.