### PR TITLE
Improving use of semaphore to wait for the async result to finish

### DIFF
--- a/Sources/JSONRequest.swift
+++ b/Sources/JSONRequest.swift
@@ -153,15 +153,14 @@ open class JSONRequest {
         var requestResult: JSONResult = JSONResult.failure(error: JSONError.unknownError,
                                                            response: nil, body: nil)
 
-        let group = DispatchGroup()
-        group.enter()
+        let semaphore = DispatchSemaphore(value: 0)
         submitAsyncRequest(method: method, url: url, queryParams: queryParams,
                            payload: payload, headers: headers, timeOut: timeOut) { result in
                             requestResult = result
-                            group.leave()
+                            semaphore.signal()
         }
         // Wait for the request to complete
-        group.wait()    // Timeout will be handled by the HTTP layer
+        semaphore.wait()    // Timeout will be handled by the HTTP layer
         return requestResult
     }
 

--- a/Sources/JSONRequest.swift
+++ b/Sources/JSONRequest.swift
@@ -150,19 +150,18 @@ open class JSONRequest {
                            headers: JSONObject? = nil,
                            timeOut: TimeInterval? = nil) -> JSONResult {
 
-        let semaphore = DispatchSemaphore(value: 0)
         var requestResult: JSONResult = JSONResult.failure(error: JSONError.unknownError,
                                                            response: nil, body: nil)
+
+        let group = DispatchGroup()
+        group.enter()
         submitAsyncRequest(method: method, url: url, queryParams: queryParams,
                            payload: payload, headers: headers, timeOut: timeOut) { result in
                             requestResult = result
-                            semaphore.signal()
+                            group.leave()
         }
         // Wait for the request to complete
-        while semaphore.wait(timeout: DispatchTime.now()) == .timedOut {
-            let intervalDate = Date(timeIntervalSinceNow: 0.01) // 10 milliseconds
-            RunLoop.current.run(mode: RunLoopMode.defaultRunLoopMode, before: intervalDate)
-        }
+        group.wait()    // Timeout will be handled by the HTTP layer
         return requestResult
     }
 


### PR DESCRIPTION
The way we were polling using a Semaphore previously was very inefficient and would cause CPU pegging when multiple calls were being made at once. I’ve moved to use a DispatchGroup which seems to be much more efficient and effective, the results have been quite impressive in my local tests.

This was initially observed on a client project when a push notification was received and multiple JSONRequests were fired off at the same time -- I would see delays of up to 10 seconds and CPU pegging during that entire time until things cleared up. With this new implementation I see requests finish within a couple seconds and CPU usage never goes over 30-40% during that time, so it definitely seems more efficient.

I tried to figure out a way to implement without using DispatchGroup (i.e. DispatchWorkItem), but I couldn't figure out how to accomplish signaling that the task was complete within the callback closure... I'm definitely open to suggestions on ways to use something other than DispatchGroup, although I'm personally a fan of the class's architecture.