### PR TITLE
Add delegate to allow modifying the URLSessionConfiguration

### DIFF
--- a/Sources/JSONRequest.swift
+++ b/Sources/JSONRequest.swift
@@ -91,6 +91,8 @@ open class JSONRequest {
     /* Set to false during testing to avoid test failures due to lack of internet access */
     internal static var requireNetworkAccess = true
 
+    public static var sessionConfigurationDelegate: ((URLSessionConfiguration) -> Void)?
+
     /* Omit the session parameter to use the default URLSession */
     public init(session: URLSession? = nil) {
         urlSession = session
@@ -141,6 +143,7 @@ open class JSONRequest {
         if let userAgent = JSONRequest.userAgent {
             config.httpAdditionalHeaders = ["User-Agent": userAgent]
         }
+        JSONRequest.sessionConfigurationDelegate?(config)
         return URLSession(configuration: config)
     }
 

--- a/Sources/JSONRequest.swift
+++ b/Sources/JSONRequest.swift
@@ -91,6 +91,10 @@ open class JSONRequest {
     /* Set to false during testing to avoid test failures due to lack of internet access */
     internal static var requireNetworkAccess = true
 
+    /* Delegate that allows additional configurations to be made to the URLSessionConfiguration used for the JSONRequest instance.
+        This delegate will be called *after* JSONRequest configures the instance for its needs. Keep in mind making
+        significant changes to the URLSessionConfiguration object could cause undefined behavior that JSONRequest cannot control.
+    */
     public static var sessionConfigurationDelegate: ((URLSessionConfiguration) -> Void)?
 
     /* Omit the session parameter to use the default URLSession */


### PR DESCRIPTION
This was initially created to support hooking up an Instabug logger to the HTTP session to get automatic HTTP logging, but theoretically could be used for other purposes.

This delegate is called after JSONRequest configures the object, so there is the potential for the consumer of the object to mess some things up, but...

![](https://i.giphy.com/media/MCZ39lz83o5lC/giphy.webp)