### PR TITLE
MAINT | Security | ABEMA-904: Enabled ability to disable URL Caching

### DIFF
--- a/Sources/JSONRequest.swift
+++ b/Sources/JSONRequest.swift
@@ -91,6 +91,9 @@ open class JSONRequest {
     open static var requestCachePolicy: NSURLRequest.CachePolicy = .useProtocolCachePolicy {
         didSet { updateSessionConfig() }
     }
+    open static var isURLCacheEnabled: Bool = true {
+        didSet { updateSessionConfig() }
+    }
 
     open static let serviceTripTimeNotification = NSNotification.Name("JSON_REQUEST_TRIP_TIME_NOTIFICATION")
 
@@ -125,7 +128,7 @@ open class JSONRequest {
         sessionConfig.timeoutIntervalForResource = resourceTimeout
         sessionConfig.timeoutIntervalForRequest = requestTimeout
         let capacity: Int = (maxEstimatedResponseMegabytes * 20) * 1024 * 1024 // max response should be less than 5% of cache size
-        let urlCache = URLCache(memoryCapacity: capacity, diskCapacity: capacity, diskPath: nil)
+        let urlCache: URLCache? = isURLCacheEnabled ? URLCache(memoryCapacity: capacity, diskCapacity: capacity, diskPath: nil) : nil
         sessionConfig.urlCache = urlCache
         urlSession = URLSession(configuration: JSONRequest.sessionConfig)
     }


### PR DESCRIPTION
Putting this in won't require changes and won't affect your project. 
I've created and exposed an `isURLCachingEnabled` flag to allow for disabling URL Caching. 
This comes as a security request from a client that doesn't want all of our requests cached in the device's `cache.db`.