### PR TITLE
Use sessionConfig's JSONRequest timeout value

### DIFF
--- a/Sources/JSONRequest.swift
+++ b/Sources/JSONRequest.swift
@@ -153,7 +153,7 @@ open class JSONRequest {
 
         var request = URLRequest(url: URL(string: url)!,
                                  cachePolicy: JSONRequest.requestCachePolicy,
-                                 timeoutInterval: timeOut ?? 10.0)
+                                 timeoutInterval: timeOut ?? JSONRequest.requestTimeout)
 
         updateRequest(&request, method: method, url: url, queryParams: queryParams)
         updateRequest(&request, headers: headers)


### PR DESCRIPTION
This change in the URLRequest initializer, to fall back to a 10 second timeout value, was causing all requests in Peet's to have a 10-second timeout.  

This change instead instructs `JSONRequest` to fall back to its sessionconfig's `requestTimeout` value if no value is given for the optional `timeOut` parameter.