### PR TITLE
Async method improvements

### DIFF
--- a/JSONRequestTests/JSONRequestDELETETests.swift
+++ b/JSONRequestTests/JSONRequestDELETETests.swift
@@ -56,7 +56,7 @@ class JSONRequestDELETETests: XCTestCase {
 
     func testFailing() {
         // We don't use DVR on this test because it is designed to fail immediately
-        let result = JSONRequest.delete(url: badUrl, queryParams: params)
+        let result = JSONRequest().delete(url: badUrl, queryParams: params)
         switch result {
         case .success:
             XCTFail("Request should have failed")

--- a/JSONRequestTests/JSONRequestDELETETests.swift
+++ b/JSONRequestTests/JSONRequestDELETETests.swift
@@ -71,7 +71,7 @@ class JSONRequestDELETETests: XCTestCase {
     func testAsync() {
         let jsonRequest = JSONRequest(session: DVR.Session(cassetteName: "testFiles/testAsyncDELETE"))
         let expectation = self.expectation(description: "async")
-        jsonRequest.delete(url: goodUrl) { (result) in
+        jsonRequest.send(.DELETE, url: goodUrl) { (result) in
             XCTAssertNil(result.error)
             expectation.fulfill()
         }
@@ -85,7 +85,7 @@ class JSONRequestDELETETests: XCTestCase {
     func testAsyncFail() {
         // We don't use DVR on this test because it is designed to fail immediately
         let expectation = self.expectation(description: "async")
-        JSONRequest.delete(url: badUrl) { (result) in
+        JSONRequest().send(.DELETE, url: badUrl) { (result) in
             XCTAssertNotNil(result.error)
             expectation.fulfill()
         }

--- a/JSONRequestTests/JSONRequestGETTests.swift
+++ b/JSONRequestTests/JSONRequestGETTests.swift
@@ -71,7 +71,7 @@ class JSONRequestGETTests: XCTestCase {
     func testAsync() {
         let jsonRequest = JSONRequest(session: DVR.Session(cassetteName: "testFiles/testAsyncGET"))
         let expectation = self.expectation(description: "async")
-        jsonRequest.get(url: goodUrl) { (result) in
+        jsonRequest.send(.GET, url: goodUrl) { (result) in
             XCTAssertNil(result.error)
             expectation.fulfill()
         }
@@ -85,7 +85,7 @@ class JSONRequestGETTests: XCTestCase {
     func testAsyncFail() {
         // We don't use DVR on this test because it is designed to fail immediately
         let expectation = self.expectation(description: "async")
-        JSONRequest.get(url: badUrl) { (result) in
+        JSONRequest().send(.GET, url: badUrl) { (result) in
             XCTAssertNotNil(result.error)
             expectation.fulfill()
         }

--- a/JSONRequestTests/JSONRequestGETTests.swift
+++ b/JSONRequestTests/JSONRequestGETTests.swift
@@ -56,7 +56,7 @@ class JSONRequestGETTests: XCTestCase {
 
     func testFailing() {
         // We don't use DVR on this test because it is designed to fail immediately
-        let result = JSONRequest.get(url: badUrl, queryParams: params)
+        let result = JSONRequest().get(url: badUrl, queryParams: params)
         switch result {
         case .success:
             XCTFail("Request should have failed")

--- a/JSONRequestTests/JSONRequestPATCHTests.swift
+++ b/JSONRequestTests/JSONRequestPATCHTests.swift
@@ -59,7 +59,7 @@ class JSONRequestPATCHTests: XCTestCase {
 
     func testFailing() {
         // We don't use DVR on this test because it is designed to fail immediately
-        let result = JSONRequest.patch(url: badUrl, payload: payload)
+        let result = JSONRequest().patch(url: badUrl, payload: payload)
         switch result {
         case .success:
             XCTFail("Request should have failed")

--- a/JSONRequestTests/JSONRequestPATCHTests.swift
+++ b/JSONRequestTests/JSONRequestPATCHTests.swift
@@ -74,7 +74,7 @@ class JSONRequestPATCHTests: XCTestCase {
     func testAsync() {
         let jsonRequest = JSONRequest(session: DVR.Session(cassetteName: "testFiles/testAsyncPATCH"))
         let expectation = self.expectation(description: "async")
-        jsonRequest.patch(url: goodUrl) { (result) in
+        jsonRequest.send(.PATCH, url: goodUrl) { (result) in
             XCTAssertNil(result.error)
             expectation.fulfill()
         }
@@ -88,7 +88,7 @@ class JSONRequestPATCHTests: XCTestCase {
     func testAsyncFail() {
         // We don't use DVR on this test because it is designed to fail immediately
         let expectation = self.expectation(description: "async")
-        JSONRequest.patch(url: badUrl) { (result) in
+        JSONRequest().send(.PATCH, url: badUrl) { (result) in
             XCTAssertNotNil(result.error)
             expectation.fulfill()
         }

--- a/JSONRequestTests/JSONRequestPOSTTests.swift
+++ b/JSONRequestTests/JSONRequestPOSTTests.swift
@@ -59,7 +59,7 @@ class JSONRequestPOSTTests: XCTestCase {
 
     func testFailing() {
         // We don't use DVR on this test because it is designed to fail immediately
-        let result = JSONRequest.post(url: badUrl, payload: payload)
+        let result = JSONRequest().post(url: badUrl, payload: payload)
         switch result {
         case .success:
             XCTFail("Request should have failed")

--- a/JSONRequestTests/JSONRequestPOSTTests.swift
+++ b/JSONRequestTests/JSONRequestPOSTTests.swift
@@ -74,7 +74,7 @@ class JSONRequestPOSTTests: XCTestCase {
     func testAsync() {
         let jsonRequest = JSONRequest(session: DVR.Session(cassetteName: "testFiles/testAsyncPOST"))
         let expectation = self.expectation(description: "async")
-        jsonRequest.post(url: goodUrl) { (result) in
+        jsonRequest.send(.POST, url: goodUrl) { (result) in
             XCTAssertNil(result.error)
             expectation.fulfill()
         }
@@ -88,7 +88,7 @@ class JSONRequestPOSTTests: XCTestCase {
     func testAsyncFail() {
         // We don't use DVR on this test because it is designed to fail immediately
         let expectation = self.expectation(description: "async")
-        JSONRequest.post(url: badUrl) { (result) in
+        JSONRequest().send(.POST, url: badUrl) { (result) in
             XCTAssertNotNil(result.error)
             expectation.fulfill()
         }

--- a/JSONRequestTests/JSONRequestPUTTests.swift
+++ b/JSONRequestTests/JSONRequestPUTTests.swift
@@ -59,7 +59,7 @@ class JSONRequestPUTTests: XCTestCase {
 
     func testFailing() {
         // We don't use DVR on this test because it is designed to fail immediately
-        let result = JSONRequest.put(url: badUrl, payload: payload)
+        let result = JSONRequest().put(url: badUrl, payload: payload)
         switch result {
         case .success:
             XCTFail("Request should have failed")

--- a/JSONRequestTests/JSONRequestPUTTests.swift
+++ b/JSONRequestTests/JSONRequestPUTTests.swift
@@ -74,7 +74,7 @@ class JSONRequestPUTTests: XCTestCase {
     func testAsync() {
         let jsonRequest = JSONRequest(session: DVR.Session(cassetteName: "testFiles/testAsyncPUT"))
         let expectation = self.expectation(description: "async")
-        jsonRequest.put(url: goodUrl) { (result) in
+        jsonRequest.send(.PUT, url: goodUrl) { (result) in
             XCTAssertNil(result.error)
             expectation.fulfill()
         }
@@ -88,7 +88,7 @@ class JSONRequestPUTTests: XCTestCase {
     func testAsyncFail() {
         // We don't use DVR on this test because it is designed to fail immediately
         let expectation = self.expectation(description: "async")
-        JSONRequest.put(url: badUrl) { (result) in
+        JSONRequest().send(.PUT, url: badUrl) { (result) in
             XCTAssertNotNil(result.error)
             expectation.fulfill()
         }

--- a/Sources/JSONRequest.swift
+++ b/Sources/JSONRequest.swift
@@ -153,7 +153,7 @@ open class JSONRequest {
     ///   - method: HTTP Method (GET|POST|PUT|PATCH|DELETE)
     ///   - url: Destination URL
     ///   - queryParams: Query parameters
-    ///   - payload: BOdy parameters
+    ///   - payload: Body parameters
     ///   - headers: Headers
     ///   - timeOut: Request timeout
     ///   - complete: Completion handler which accepts Result value

--- a/Sources/JSONRequest.swift
+++ b/Sources/JSONRequest.swift
@@ -30,6 +30,12 @@ public enum JSONResult {
     case failure(error: JSONError, response: HTTPURLResponse?, body: String?)
 }
 
+public protocol JSONCancellableRequest {
+    func cancel()
+}
+
+extension URLSessionDataTask: JSONCancellableRequest {}
+
 public extension JSONResult {
 
     public var data: Any? {
@@ -141,13 +147,23 @@ open class JSONRequest {
 
     // MARK: Non-public business logic (testable but not public outside the module)
 
-    func submitAsyncRequest(method: JSONRequestHttpVerb, url: String,
-                            queryParams: JSONObject? = nil, payload: Any? = nil,
-                            headers: JSONObject? = nil, timeOut: TimeInterval? = nil, complete: @escaping (JSONResult) -> Void) {
+    /// Method for sending asynchronous requests
+    ///
+    /// - Parameters:
+    ///   - method: HTTP Method (GET|POST|PUT|PATCH|DELETE)
+    ///   - url: Destination URL
+    ///   - queryParams: Query parameters
+    ///   - payload: BOdy parameters
+    ///   - headers: Headers
+    ///   - timeOut: Request timeout
+    ///   - complete: Completion handler which accepts Result value
+    /// - Returns: Active request which can be cancelled
+    @discardableResult
+    public func send(_ method: JSONRequestHttpVerb, url: String, queryParams: JSONObject? = nil, payload: Any? = nil, headers: JSONObject? = nil, timeOut: TimeInterval? = nil, complete: @escaping (JSONResult) -> Void) -> JSONCancellableRequest? {
         if (isConnectedToNetwork() == false) && (JSONRequest.requireNetworkAccess) {
             let error = JSONError.noInternetConnection
             complete(.failure(error: error, response: nil, body: nil))
-            return
+            return nil
         }
 
         var request = URLRequest(url: URL(string: url)!, cachePolicy: JSONRequest.requestCachePolicy, timeoutInterval: timeOut ?? JSONRequest.requestTimeout)
@@ -193,6 +209,7 @@ open class JSONRequest {
         }
         trace(task: task)
         task.resume()
+        return task
     }
 
     func networkSession(forcedTimeout: TimeInterval? = nil) -> URLSession {
@@ -218,7 +235,7 @@ open class JSONRequest {
                                                            response: nil, body: nil)
 
         let semaphore = DispatchSemaphore(value: 0)
-        submitAsyncRequest(method: method, url: url, queryParams: queryParams,
+        send(method, url: url, queryParams: queryParams,
                            payload: payload, headers: headers, timeOut: timeOut) { result in
                             requestResult = result
                             semaphore.signal()

--- a/Sources/JSONRequestVerbs.swift
+++ b/Sources/JSONRequestVerbs.swift
@@ -57,37 +57,3 @@ public extension JSONRequest {
     }
 
 }
-
-// MARK: Class HTTP Sync methods
-
-public extension JSONRequest {
-
-    public class func get(url: String, queryParams: JSONObject? = nil,
-                          headers: JSONObject? = nil) -> JSONResult {
-        return JSONRequest().get(url: url, queryParams: queryParams, headers: headers)
-    }
-
-    public class func post(url: String, queryParams: JSONObject? = nil, payload: Any? = nil,
-                           headers: JSONObject? = nil) -> JSONResult {
-        return JSONRequest().post(url: url, queryParams: queryParams, payload: payload,
-                                  headers: headers)
-    }
-
-    public class func put(url: String, queryParams: JSONObject? = nil, payload: Any? = nil,
-                          headers: JSONObject? = nil) -> JSONResult {
-        return JSONRequest().put(url: url, queryParams: queryParams, payload: payload,
-                                 headers: headers)
-    }
-
-    public class func patch(url: String, queryParams: JSONObject? = nil, payload: Any? = nil,
-                            headers: JSONObject? = nil) -> JSONResult {
-        return JSONRequest().patch(url: url, queryParams: queryParams, payload: payload,
-                                   headers: headers)
-    }
-
-    public class func delete(url: String, queryParams: JSONObject? = nil,
-                             headers: JSONObject? = nil) -> JSONResult {
-        return JSONRequest().delete(url: url, queryParams: queryParams, headers: headers)
-    }
-
-}

--- a/Sources/JSONRequestVerbs.swift
+++ b/Sources/JSONRequestVerbs.swift
@@ -17,15 +17,6 @@ public enum JSONRequestHttpVerb: String {
 // MARK: Instance basic sync/async
 
 extension JSONRequest {
-
-    public func send(method: JSONRequestHttpVerb, url: String, queryParams: JSONObject? = nil,
-                     payload: Any? = nil, headers: JSONObject? = nil,
-                     complete: @escaping (JSONResult) -> Void) {
-
-        submitAsyncRequest(method: method, url: url, queryParams: queryParams, payload: payload,
-                           headers: headers, complete: complete)
-    }
-
     public func send(method: JSONRequestHttpVerb, url: String, queryParams: JSONObject? = nil,
                      payload: Any? = nil, headers: JSONObject? = nil, timeOut: TimeInterval? = nil) -> JSONResult {
         return submitSyncRequest(method: method, url: url, queryParams: queryParams,
@@ -35,7 +26,6 @@ extension JSONRequest {
 }
 
 // MARK: Instance HTTP Sync methods
-
 public extension JSONRequest {
 
     public func get(url: String, queryParams: JSONObject? = nil,
@@ -64,42 +54,6 @@ public extension JSONRequest {
     public func delete(url: String, queryParams: JSONObject? = nil,
                        headers: JSONObject? = nil) -> JSONResult {
         return send(method: .DELETE, url: url, queryParams: queryParams, headers: headers)
-    }
-
-}
-
-// MARK: Instance HTTP Async methods
-
-public extension JSONRequest {
-
-    public func get(url: String, queryParams: JSONObject? = nil, headers: JSONObject? = nil,
-                    complete: @escaping (JSONResult) -> Void) {
-        send(method: .GET, url: url, queryParams: queryParams, headers: headers,
-             complete: complete)
-    }
-
-    public func post(url: String, queryParams: JSONObject? = nil, payload: Any? = nil,
-                     headers: JSONObject? = nil, complete: @escaping (JSONResult) -> Void) {
-        send(method: .POST, url: url, queryParams: queryParams, payload: payload,
-             headers: headers, complete: complete)
-    }
-
-    public func put(url: String, queryParams: JSONObject? = nil, payload: Any? = nil,
-                    headers: JSONObject? = nil, complete: @escaping (JSONResult) -> Void) {
-        send(method: .PUT, url: url, queryParams: queryParams, payload: payload,
-             headers: headers, complete: complete)
-    }
-
-    public func patch(url: String, queryParams: JSONObject? = nil, payload: Any? = nil,
-                      headers: JSONObject? = nil, complete: @escaping (JSONResult) -> Void) {
-        send(method: .PATCH, url: url, queryParams: queryParams, payload: payload,
-             headers: headers, complete: complete)
-    }
-
-    public func delete(url: String, queryParams: JSONObject? = nil, payload: Any? = nil,
-                       headers: JSONObject? = nil, complete: @escaping (JSONResult) -> Void) {
-        send(method: .DELETE, url: url, queryParams: queryParams, headers: headers,
-             complete: complete)
     }
 
 }
@@ -136,38 +90,4 @@ public extension JSONRequest {
         return JSONRequest().delete(url: url, queryParams: queryParams, headers: headers)
     }
 
-}
-
-// MARK: Class HTTP Async methods
-
-public extension JSONRequest {
-
-    public class func get(url: String, queryParams: JSONObject? = nil, headers: JSONObject? = nil,
-                          complete: @escaping (JSONResult) -> Void) {
-        JSONRequest().get(url: url, queryParams: queryParams, headers: headers, complete: complete)
-    }
-
-    public class func post(url: String, queryParams: JSONObject? = nil, payload: Any? = nil,
-                           headers: JSONObject? = nil, complete: @escaping (JSONResult) -> Void) {
-        JSONRequest().post(url: url, queryParams: queryParams, payload: payload, headers: headers,
-                           complete: complete)
-    }
-
-    public class func put(url: String, queryParams: JSONObject? = nil, payload: Any? = nil,
-                          headers: JSONObject? = nil, complete: @escaping (JSONResult) -> Void) {
-        JSONRequest().put(url: url, queryParams: queryParams, payload: payload, headers: headers,
-                          complete: complete)
-    }
-
-    public class func patch(url: String, queryParams: JSONObject? = nil, payload: Any? = nil,
-                            headers: JSONObject? = nil, complete: @escaping (JSONResult) -> Void) {
-        JSONRequest().patch(url: url, queryParams: queryParams, payload: payload, headers: headers,
-                            complete: complete)
-    }
-
-    public class func delete(url: String, queryParams: JSONObject? = nil,
-                             headers: JSONObject? = nil, complete: @escaping (JSONResult) -> Void) {
-        JSONRequest().delete(url: url, queryParams: queryParams, headers: headers,
-                             complete: complete)
-    }
 }


### PR DESCRIPTION
- Returning active request from async `send` method
- Removed redundant methods for all the request methods, now there only one async method, which accepts request method as a first parameter